### PR TITLE
Fix URL for README that is opened after nuget install

### DIFF
--- a/Nuget/tools/install.ps1
+++ b/Nuget/tools/install.ps1
@@ -1,6 +1,6 @@
 param($installPath, $toolsPath, $package, $project)
 
-$project.DTE.ItemOperations.Navigate('http://github.com/bitstadium/HockeySDK-Windows/readme.txt')
+$project.DTE.ItemOperations.Navigate('https://github.com/bitstadium/HockeySDK-Windows/blob/develop/README.md')
 
 //TODO braucht es das oder ist content der default ?! funzt das mit Extension (orig: Name)
 $item = $project.ProjectItems | where-object {$_.Extension -eq "png"} 


### PR DESCRIPTION
This should be updated again if the master branch ever
becomes the desired place to look for the README.
