### PR TITLE
Fixes for HockeyPlatformHelperWPF

### DIFF
--- a/HockeySDK_WPF/HockeyPlatformHelperWPF.cs
+++ b/HockeySDK_WPF/HockeyPlatformHelperWPF.cs
@@ -71,6 +71,11 @@ namespace HockeyApp
 
         public async Task WriteStreamToFileAsync(Stream dataStream, string fileName, string folderName = null)
         {
+            // Ensure crashes folder exists
+            if (!isoStore.DirectoryExists(folderName)) {
+                isoStore.CreateDirectory(folderName);
+            }
+
             using (var fileStream = isoStore.OpenFile((folderName ?? "") + Path.DirectorySeparatorChar + fileName,FileMode.Create,FileAccess.Write)) {
                 await dataStream.CopyToAsync(fileStream);
             }
@@ -78,7 +83,11 @@ namespace HockeyApp
 
         public async Task<IEnumerable<string>> GetFileNamesAsync(string folderName = null, string fileNamePattern = null)
         {
-            return isoStore.GetFileNames((folderName ?? "") + Path.DirectorySeparatorChar + fileNamePattern ?? "*");
+            try {
+                return isoStore.GetFileNames((folderName ?? "") + Path.DirectorySeparatorChar + fileNamePattern ?? "*");
+            } catch (DirectoryNotFoundException) {
+                return new string[0];
+            }
         }
 
         #endregion


### PR DESCRIPTION
This pull request fixes generation of crash file paths, ensures the crashes folder exists before writing the crash file, and ensures GetFileNamesAsync does not throw an exception if the crashes folder doesn't exist.
