### PR TITLE
Disable handlers for UnobservedTaskException by default

### DIFF
--- a/HockeySDK_WPF/HockeyClientWPFExtensions.cs
+++ b/HockeySDK_WPF/HockeyClientWPFExtensions.cs
@@ -27,7 +27,6 @@ namespace HockeyApp
 
             AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
             Application.Current.DispatcherUnhandledException += Current_DispatcherUnhandledException;
-            TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
 
             return (IHockeyClientConfigurable)@this;
         }
@@ -35,6 +34,17 @@ namespace HockeyApp
         private static Action<UnhandledExceptionEventArgs> customUnhandledExceptionAction;
         private static Action<UnobservedTaskExceptionEventArgs> customUnobservedTaskExceptionAction;
         private static Action<DispatcherUnhandledExceptionEventArgs> customDispatcherUnhandledExceptionAction;
+
+        /// <summary>
+        /// Adds the handler for UnobservedTaskExceptions
+        /// </summary>
+        /// <param name="this"></param>
+        /// <returns></returns>
+        public static IHockeyClientConfigurable RegisterDefaultUnobservedTaskExceptionHandler(this IHockeyClientConfigurable @this)
+        {
+            TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
+            return @this;
+        }
 
         /// <summary>
         /// Removes the handler for UnobservedTaskExceptions

--- a/HockeySDK_WinForms45/HockeyClientWinFormsExtensions.cs
+++ b/HockeySDK_WinForms45/HockeyClientWinFormsExtensions.cs
@@ -28,9 +28,30 @@ namespace HockeyApp
                 Application.ThreadException += Current_ThreadException;
                 Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException);
             }
-            TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
 
             return (IHockeyClientConfigurable)@this;
+        }
+
+        /// <summary>
+        /// Adds the handler for UnobservedTaskExceptions
+        /// </summary>
+        /// <param name="this"></param>
+        /// <returns></returns>
+        public static IHockeyClientConfigurable RegisterDefaultUnobservedTaskExceptionHandler(this IHockeyClientConfigurable @this)
+        {
+            TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
+            return @this;
+        }
+
+        /// <summary>
+        /// Removes the handler for UnobservedTaskExceptions
+        /// </summary>
+        /// <param name="this"></param>
+        /// <returns></returns>
+        public static IHockeyClientConfigurable UnregisterDefaultUnobservedTaskExceptionHandler(this IHockeyClientConfigurable @this)
+        {
+            TaskScheduler.UnobservedTaskException -= TaskScheduler_UnobservedTaskException;
+            return @this;
         }
 
         static async void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)


### PR DESCRIPTION
Since .NET 4.5, by default, UnobservedTaskExceptions do no longer cause
the app to crash. The SDK has not been adapted for this and still logs
these errors and causes the program to exit, though this might not be
needed or intended.

This commit changes the default behavior to NOT add any handlers for
UnobservedTaskException.

Users who wish to continue using the handler, should add calls to
`RegisterUnobservedTaskExceptionHandler()` or
`RegisterDefaultUnobservedTaskExceptionHandler()`  after calling
`Configure()`.

Fixes #29.
Fixes #27 for other platforms than WPF.