### PR TITLE
Retrieving Namespace fix

### DIFF
--- a/HockeySDK_WinForms45/HockeyPlatformHelperWinForms.cs
+++ b/HockeySDK_WinForms45/HockeyPlatformHelperWinForms.cs
@@ -118,8 +118,14 @@ namespace HockeyApp
         {
             get
             {
-                if(_appPackageName == null) {
-                    _appPackageName = Assembly.GetEntryAssembly().EntryPoint.DeclaringType.Namespace;
+                if (_appPackageName == null) {
+                    if (Assembly.GetExecutingAssembly().EntryPoint != null) {
+                        _appPackageName = Assembly.GetExecutingAssembly().EntryPoint.DeclaringType.Namespace;
+                    } else if (Assembly.GetEntryAssembly().EntryPoint != null) {
+                        _appPackageName = Assembly.GetEntryAssembly().EntryPoint.DeclaringType.Namespace;
+                    } else {
+                        _appPackageName = "unknown";
+                    }
                 }
                 return _appPackageName;
             }

--- a/HockeySDK_WinForms45/HockeyPlatformHelperWinForms.cs
+++ b/HockeySDK_WinForms45/HockeyPlatformHelperWinForms.cs
@@ -119,7 +119,7 @@ namespace HockeyApp
             get
             {
                 if(_appPackageName == null) {
-                    _appPackageName = Assembly.GetExecutingAssembly().EntryPoint.DeclaringType.Namespace;
+                    _appPackageName = Assembly.GetEntryAssembly().EntryPoint.DeclaringType.Namespace;
                 }
                 return _appPackageName;
             }


### PR DESCRIPTION
The code was using Assembly.GetExecutingAssembly() which is currently
the DLL and has no entry point function. Changed to
Assembly.GetEntryAssembly()