### PR TITLE
Add Background Task support

### DIFF
--- a/Src/Kit.Core45/Channels/InMemory/ITelemetryChannel.cs
+++ b/Src/Kit.Core45/Channels/InMemory/ITelemetryChannel.cs
@@ -31,5 +31,10 @@ namespace Microsoft.HockeyApp.Channel
         /// Flushes the in-memory buffer.
         /// </summary>
         void Flush();
+
+        /// <summary>
+        /// Flushes the in-memory buffer to disk and attempt to send telemetry data.
+        /// </summary>
+        void FlushAndSend();
     }
 }

--- a/Src/Kit.Core45/Channels/InMemory/InMemoryChannel.cs
+++ b/Src/Kit.Core45/Channels/InMemory/InMemoryChannel.cs
@@ -145,6 +145,15 @@ namespace Microsoft.HockeyApp.Channel
         }
 
         /// <summary>
+        /// Will send all the telemetry items stored in the memory.
+        /// Same as a Flush() call for InMemoryChannel.
+        /// </summary>
+        public void FlushAndSend()
+        {
+            this.Flush();
+        }
+
+        /// <summary>
         /// Disposing the channel.
         /// </summary>
         public void Dispose()

--- a/Src/Kit.Core45/Channels/Persistence/PersistenceChannel.cs
+++ b/Src/Kit.Core45/Channels/Persistence/PersistenceChannel.cs
@@ -269,6 +269,15 @@ namespace Microsoft.HockeyApp.Channel
         public void Flush()
         {   
             this.flushManager.Flush();
-        }        
+        }    
+        
+        /// <summary>
+        /// Flushes the in-memory buffer to disk and attempt to send telemetry data.
+        /// </summary>
+        public void FlushAndSend()
+        {
+            this.Flush();
+            this.Transmitter.Flush();
+        }    
     }
 }

--- a/Src/Kit.Core45/Channels/Persistence/PersistenceTransmitter.cs
+++ b/Src/Kit.Core45/Channels/Persistence/PersistenceTransmitter.cs
@@ -120,5 +120,19 @@ namespace Microsoft.HockeyApp.Channel
 
             Task.WaitAll(stoppedTasks.ToArray());
         }
+
+        /// <summary>
+        /// Flushed the persistent telemetry data to the endpoint. 
+        /// </summary>
+        internal void Flush()
+        {
+            var flushTasks = new List<Task>();
+            foreach (var sender in this.senders)
+            {
+                flushTasks.Add(sender.FlushAsync());
+            }
+
+            Task.WaitAll(flushTasks.ToArray());
+        }
     }
 }

--- a/Src/Kit.Core45/HockeyClient.cs
+++ b/Src/Kit.Core45/HockeyClient.cs
@@ -1194,6 +1194,15 @@
             this.Channel.Flush();
         }
 
+        /// <summary>
+        /// Clears all buffers for this telemetry stream and causes any buffered data to be written to the underlying channel.
+        /// And send all persistent telemetry data, if persistence channel is used and if possible with current conditions otherwise telemetry data still persist.
+        /// </summary>
+        public void FlushAndSendPersistentTelemetry()
+        {
+            this.Channel.FlushAndSend();
+        }
+
         private async Task<TelemetryContext> CreateInitializedContextAsync()
         {
             var context = new TelemetryContext();

--- a/Src/Kit.Core45/IHockeyClient.cs
+++ b/Src/Kit.Core45/IHockeyClient.cs
@@ -113,5 +113,11 @@ namespace Microsoft.HockeyApp
         /// Clears all buffers for this telemetry stream and causes any buffered data to be written to the underlying channel.
         /// </summary>
         void Flush();
+
+        /// <summary>
+        /// Clears all buffers for this telemetry stream and causes any buffered data to be written to the underlying channel.
+        /// And send all persistent telemetry data, if persistence channel is used and if possible with current conditions otherwise telemetry data still persist.
+        /// </summary>
+        void FlushAndSendPersistentTelemetry();
     }
 }

--- a/Src/Kit.UWP.Tests/StubTelemetryChannel.cs
+++ b/Src/Kit.UWP.Tests/StubTelemetryChannel.cs
@@ -63,5 +63,12 @@
         public void Flush()
         {   
         }
+
+        /// <summary>
+        /// Mock for the FlushAndSend method in <see cref="ITelemetryChannel"/>.
+        /// </summary>
+        public void FlushAndSend()
+        {
+        }
     }
 }

--- a/Src/Kit.UWP/Services/ApplicationService.cs
+++ b/Src/Kit.UWP/Services/ApplicationService.cs
@@ -103,11 +103,7 @@
         {
             if (this.fullPackageName == null)
             {
-#if WP8
-                this.fullPackageName = System.Windows.Application.Current.GetType().Namespace;
-#else
-                this.fullPackageName =  global::Windows.UI.Xaml.Application.Current.GetType().Namespace;
-#endif
+                this.fullPackageName = Package.Current.Id.FullName;
             }
 
             return this.fullPackageName;


### PR DESCRIPTION
Hello,

I am an old Application Insights user and some AI APIs allowed me to implement a custom support of Background Tasks. After migration to HockeyApp, I have again the problem: no support of Background Tasks.

So, I have made some changes to add Background Task support:
1. Using Package.Id.FullName instead of App namespace. I have made this change because "Windows.UI.Xaml.Application" namespace is not available in Background Tasks and Package.Id.FullName is proper information for an UWP app.
2. Adding HockeyClient.FlushAndSendPersistentTelemetry() method to flush and send existing transmissions if Internet is available. Existing HockeyClient.Flush() method is only saving to the disk in-memory transmissions without send before close of the app. For the (UI) app is not necessary required because transmissions are send at the next app start. But if the app not need to be open, Background Task generated transmissions who his never send. This new method allow, if necessary, to send transmissions after a disk-flush. Equivalant to the existing flush logic of in-memory channel.

With this two changes, I use HockeySDK to send telemetry data from Background Tasks and it is working nicely with no huge impact on performances. You can test with [this custom release](https://github.com/ChristopheLav/HockeySDK-Windows/releases/tag/4.1.3000) based on the last 4.1.3 official version.

If you have any question, don't hesitate :-)

Best regards,
Christophe
