### PR TITLE
UnhandledExceptionTelemetryModule.CreateCrashTelemetry should handle AggregateException

### DIFF
--- a/Src/Kit.UWP/Services/UnhandledExceptionTelemetryModule.cs
+++ b/Src/Kit.UWP/Services/UnhandledExceptionTelemetryModule.cs
@@ -38,6 +38,7 @@
         public void Dispose()
         {
             CoreApplication.UnhandledErrorDetected -= CoreApplication_UnhandledErrorDetected;
+            TaskScheduler.UnobservedTaskException -= TaskScheduler_UnobservedTaskException;
         }
 
         /// <summary>

--- a/Src/Kit.UWP/Services/UnhandledExceptionTelemetryModule.cs
+++ b/Src/Kit.UWP/Services/UnhandledExceptionTelemetryModule.cs
@@ -102,6 +102,25 @@
                 }
             }
 
+            // Flatten the AggregateException and wrap it if we only have a single inner exception
+            var aggregateException = exception as AggregateException;
+            if (aggregateException != null)
+            {
+                aggregateException = aggregateException.Flatten();
+                if (aggregateException.InnerException != null)
+                {
+                    exception = aggregateException.InnerException;
+                }
+                else if (aggregateException.InnerExceptions.Count == 1)
+                {
+                    exception = aggregateException.InnerExceptions[0];
+                }
+                else
+                {
+                    exception = aggregateException;
+                }
+            }
+
             CrashTelemetryThread thread = new CrashTelemetryThread { Id = Environment.CurrentManagedThreadId };
             result.Threads.Add(thread);
             HashSet<long> seenBinaries = new HashSet<long>();

--- a/Src/Kit.UWP/Services/UnhandledExceptionTelemetryModule.cs
+++ b/Src/Kit.UWP/Services/UnhandledExceptionTelemetryModule.cs
@@ -91,7 +91,6 @@
             result.Headers.ExceptionType = exception.GetType().FullName;
             result.Headers.ExceptionReason = exception.Message;
 
-            var description = string.Empty;
             if (HockeyClient.Current.AsInternal().DescriptionLoader != null)
             {
                 try


### PR DESCRIPTION
As described in #85, when an unhandled exception is caught from Tasks, the exception might not contain a valid information or stack trace data.

So this PR implements the following idea: UnhandledExceptionTelemetryModule.CreateCrashTelemetry will now handle AggregateException, flatten it and then try to extract the inner exception if there is only one. On an unhandled Task exception, AggregateException mostly only contains one exception.