### PR TITLE
fix nuspec to include correct build outputs

### DIFF
--- a/Src/NuGet/HockeySDK.WinForms/Package.nuspec
+++ b/Src/NuGet/HockeySDK.WinForms/Package.nuspec
@@ -20,11 +20,7 @@
   </metadata>
 
   <files>
-    <!-- HockeySDK -->
+    <file src="$configuration$\Kit.WinForms45\Microsoft.HockeyApp.Kit.*" target="lib\net45" />
     <file src="$configuration$\NuGet\HockeySDK.WinForms\tools\**" target="tools" />
-    
-    <!-- Application Insights -->
-    <!-- Binaries for .NET 4.5 projects -->
-    <file src="$configuration$\Kit.WPF45\Microsoft.HockeyApp.Kit.*" target="lib\net45" />
   </files>
 </package>


### PR DESCRIPTION
WinForms nuspec referenced wpf build outputs. This PR fixes that.

I am not sure how you feel about publishing a nuget package for the winforms sdk, given that it is unsupported. I would be willing to publish under my nuget.org account as an alternative.