### PR TITLE
Fix null reference exception (Issue #80)

### DIFF
--- a/Src/Kit.Core45/Extensibility/TelemetryConfiguration.cs
+++ b/Src/Kit.Core45/Extensibility/TelemetryConfiguration.cs
@@ -68,11 +68,8 @@
             {
                 if (active == null)
                 {
-                    if (active == null)
-                    {
-                        active = new TelemetryConfiguration();
-                        TelemetryConfigurationFactory.Instance.Initialize(active);
-                    }
+                    active = new TelemetryConfiguration();
+                    TelemetryConfigurationFactory.Instance.Initialize(active);  
                 }
 
                 return active;

--- a/Src/Kit.Core45/HockeyClient.cs
+++ b/Src/Kit.Core45/HockeyClient.cs
@@ -1191,7 +1191,7 @@
         /// </summary>
         public void Flush()
         {
-            this.Channel.Flush();
+            this.Channel?.Flush();
         }
 
         private async Task<TelemetryContext> CreateInitializedContextAsync()

--- a/Src/Kit.Core45/WindowsAppInitializer.cs
+++ b/Src/Kit.Core45/WindowsAppInitializer.cs
@@ -35,6 +35,7 @@
             if (configuration == null)
             {
                 configuration = new TelemetryConfiguration();
+                TelemetryConfigurationFactory.Instance.Initialize(configuration);
             }
 
             configuration.InstrumentationKey = instrumentationKey;

--- a/Src/Kit.Core45/WindowsAppInitializer.cs
+++ b/Src/Kit.Core45/WindowsAppInitializer.cs
@@ -35,7 +35,6 @@
             if (configuration == null)
             {
                 configuration = new TelemetryConfiguration();
-                TelemetryConfigurationFactory.Instance.Initialize(configuration);
             }
 
             configuration.InstrumentationKey = instrumentationKey;


### PR DESCRIPTION
Flush would cause an error here because the channel for the active telemetry configuration was not initialized properly