### PR TITLE
Add check for whether hockey app is configured in configure method

### DIFF
--- a/Src/Kit.Core45/HockeyClient.cs
+++ b/Src/Kit.Core45/HockeyClient.cs
@@ -342,6 +342,32 @@
         }
 
         /// <summary>
+        /// Gets a value indicating whether the platform specific Configure method has been called.
+        /// </summary>
+        private bool Configured = false;
+
+        /// <summary>
+        /// Checks whether the HockeyClient is configured and sets the value to true
+        /// </summary>
+        /// <param name="iHockeyClient">The IHockeyClient instance to check</param>
+        /// <returns>False if configured was false before setting it or IHockeyClient is not an instance of HockeyClient, true otherwise</returns>
+        internal static bool CheckAndSetConfigured(IHockeyClient iHockeyClient)
+        {
+            // If Hockey Client has already  been configured, do nothing
+            HockeyClient hockeyClient = iHockeyClient as HockeyClient;
+            if (hockeyClient != null)
+            {
+                if (hockeyClient.Configured)
+                {
+                    return true;
+                }
+
+                hockeyClient.Configured = true;
+            }
+            return false;
+        }
+
+        /// <summary>
         /// Gets or sets the current context that will be used to augment telemetry you send.
         /// </summary>
         internal TelemetryContext Context

--- a/Src/Kit.Core45/HockeyClient.cs
+++ b/Src/Kit.Core45/HockeyClient.cs
@@ -341,30 +341,15 @@
             get; set;
         }
 
+        private int _isConfigured = 0;
         /// <summary>
-        /// Gets a value indicating whether the platform specific Configure method has been called.
+        /// Atomically checks if Configure has been called and sets it to true.
         /// </summary>
-        private bool Configured = false;
-
-        /// <summary>
-        /// Checks whether the HockeyClient is configured and sets the value to true
-        /// </summary>
-        /// <param name="iHockeyClient">The IHockeyClient instance to check</param>
-        /// <returns>False if configured was false before setting it or IHockeyClient is not an instance of HockeyClient, true otherwise</returns>
-        internal static bool CheckAndSetConfigured(IHockeyClient iHockeyClient)
+        /// <returns>True if the method has been previously called, false otherwise</returns>
+        public bool TestAndSetIsConfigured()
         {
-            // If Hockey Client has already  been configured, do nothing
-            HockeyClient hockeyClient = iHockeyClient as HockeyClient;
-            if (hockeyClient != null)
-            {
-                if (hockeyClient.Configured)
-                {
-                    return true;
-                }
-
-                hockeyClient.Configured = true;
-            }
-            return false;
+            const int configuredValue = 1;
+            return Interlocked.Exchange(ref _isConfigured, configuredValue) == configuredValue;
         }
 
         /// <summary>

--- a/Src/Kit.Core45/IHockeyClient.cs
+++ b/Src/Kit.Core45/IHockeyClient.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 namespace Microsoft.HockeyApp
 {
     /// <summary>
-    /// Public Interface for HockeyClient. Used by static extension methods in platfomr-specific SDKs
+    /// Public Interface for HockeyClient. Used by static extension methods in platform-specific SDKs
     /// </summary>
     public interface IHockeyClient
     {

--- a/Src/Kit.Core45/IHockeyClientInternal.cs
+++ b/Src/Kit.Core45/IHockeyClientInternal.cs
@@ -66,6 +66,12 @@
 
         bool IsTelemetryInitialized { get; set; }
 
+        /// <summary>
+        /// Atomically checks if Configure has been called and sets it to true.
+        /// </summary>
+        /// <returns>True if the method has been previously called, false otherwise</returns>
+        bool TestAndSetIsConfigured();
+
         #endregion
 
         /// <summary>
@@ -131,7 +137,6 @@
         /// <returns>Metadata of the newest version of the app</returns>
         Task<IEnumerable<IAppVersion>> GetAppVersionsAsync();
         #endregion
-
 
         #region Crash handling
 

--- a/Src/Kit.UWP/HockeyClientExtensionsUwp.cs
+++ b/Src/Kit.UWP/HockeyClientExtensionsUwp.cs
@@ -31,7 +31,6 @@
             {
                 return @this as IHockeyClientConfigurable;
             }
-            System.Diagnostics.Debug.WriteLine("Configuring");
             ServiceLocator.AddService<BaseStorageService>(new StorageService());
             ServiceLocator.AddService<IApplicationService>(new ApplicationService());
             ServiceLocator.AddService<IDeviceService>(new DeviceService());

--- a/Src/Kit.UWP/HockeyClientExtensionsUwp.cs
+++ b/Src/Kit.UWP/HockeyClientExtensionsUwp.cs
@@ -27,10 +27,11 @@
         /// <param name="configuration">Telemetry Configuration.</param>
         public static IHockeyClientConfigurable Configure(this IHockeyClient @this, string appId, TelemetryConfiguration configuration)
         {
-            if (HockeyClient.CheckAndSetConfigured(@this))
+            if (@this.AsInternal().TestAndSetIsConfigured())
             {
                 return @this as IHockeyClientConfigurable;
             }
+            System.Diagnostics.Debug.WriteLine("Configuring");
             ServiceLocator.AddService<BaseStorageService>(new StorageService());
             ServiceLocator.AddService<IApplicationService>(new ApplicationService());
             ServiceLocator.AddService<IDeviceService>(new DeviceService());

--- a/Src/Kit.UWP/HockeyClientExtensionsUwp.cs
+++ b/Src/Kit.UWP/HockeyClientExtensionsUwp.cs
@@ -27,6 +27,10 @@
         /// <param name="configuration">Telemetry Configuration.</param>
         public static IHockeyClientConfigurable Configure(this IHockeyClient @this, string appId, TelemetryConfiguration configuration)
         {
+            if (HockeyClient.CheckAndSetConfigured(@this))
+            {
+                return @this as IHockeyClientConfigurable;
+            }
             ServiceLocator.AddService<BaseStorageService>(new StorageService());
             ServiceLocator.AddService<IApplicationService>(new ApplicationService());
             ServiceLocator.AddService<IDeviceService>(new DeviceService());

--- a/Src/Kit.WP8/HockeyClientWP8SLExtension.cs
+++ b/Src/Kit.WP8/HockeyClientWP8SLExtension.cs
@@ -26,6 +26,11 @@
         /// <returns></returns>
         public static IHockeyClientConfigurable Configure(this IHockeyClient @this, string appId, TelemetryConfiguration telemetryConfiguration = null, Frame rootFrame = null)
         {
+            if (HockeyClient.CheckAndSetConfigured(@this))
+            {
+                return @this as IHockeyClientConfigurable;
+            }
+
             @this.AsInternal().PlatformHelper = new HockeyPlatformHelperWP8SL();
             @this.AsInternal().AppIdentifier = appId;
             CrashHandler.Current.Application = Application.Current;

--- a/Src/Kit.WP8/HockeyClientWP8SLExtension.cs
+++ b/Src/Kit.WP8/HockeyClientWP8SLExtension.cs
@@ -26,7 +26,7 @@
         /// <returns></returns>
         public static IHockeyClientConfigurable Configure(this IHockeyClient @this, string appId, TelemetryConfiguration telemetryConfiguration = null, Frame rootFrame = null)
         {
-            if (HockeyClient.CheckAndSetConfigured(@this))
+            if (@this.AsInternal().TestAndSetIsConfigured())
             {
                 return @this as IHockeyClientConfigurable;
             }

--- a/Src/Kit.WP81/HockeyClientExtensionsWP81.cs
+++ b/Src/Kit.WP81/HockeyClientExtensionsWP81.cs
@@ -30,7 +30,7 @@
         /// <returns>Configurable Hockey client. Configure additional settings by calling methods on the returned IHockeyClientConfigurable</returns>
         public static IHockeyClientConfigurable Configure(this IHockeyClient @this, string appIdentifier, TelemetryConfiguration configuration = null)
         {
-            if (HockeyClient.CheckAndSetConfigured(@this))
+            if (@this.AsInternal().TestAndSetIsConfigured())
             {
                 return @this as IHockeyClientConfigurable;
             }

--- a/Src/Kit.WP81/HockeyClientExtensionsWP81.cs
+++ b/Src/Kit.WP81/HockeyClientExtensionsWP81.cs
@@ -30,6 +30,11 @@
         /// <returns>Configurable Hockey client. Configure additional settings by calling methods on the returned IHockeyClientConfigurable</returns>
         public static IHockeyClientConfigurable Configure(this IHockeyClient @this, string appIdentifier, TelemetryConfiguration configuration = null)
         {
+            if (HockeyClient.CheckAndSetConfigured(@this))
+            {
+                return @this as IHockeyClientConfigurable;
+            }
+
             @this.AsInternal().PlatformHelper = new HockeyPlatformHelper81();
             @this.AsInternal().AppIdentifier = appIdentifier;
 

--- a/Src/Kit.WPF/HockeyClientWPFExtensions.cs
+++ b/Src/Kit.WPF/HockeyClientWPFExtensions.cs
@@ -44,6 +44,11 @@ namespace Microsoft.HockeyApp
         /// <returns>HockeyClient configurable.</returns>
         public static IHockeyClientConfigurable Configure(this IHockeyClient @this, string identifier)
         {
+            if (HockeyClient.CheckAndSetConfigured(@this))
+            {
+                return @this as IHockeyClientConfigurable;
+            }
+
             @this.AsInternal().AppIdentifier = identifier;
             @this.AsInternal().PlatformHelper = new HockeyPlatformHelperWPF();
 

--- a/Src/Kit.WPF/HockeyClientWPFExtensions.cs
+++ b/Src/Kit.WPF/HockeyClientWPFExtensions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.HockeyApp
         /// <returns>HockeyClient configurable.</returns>
         public static IHockeyClientConfigurable Configure(this IHockeyClient @this, string identifier)
         {
-            if (HockeyClient.CheckAndSetConfigured(@this))
+            if (@this.AsInternal().TestAndSetIsConfigured())
             {
                 return @this as IHockeyClientConfigurable;
             }

--- a/Src/Kit.Win81/HockeyClientExtensionsWin81.cs
+++ b/Src/Kit.Win81/HockeyClientExtensionsWin81.cs
@@ -25,7 +25,7 @@
         /// <returns>Configurable Hockey client. Configure additional settings by calling methods on the returned IHockeyClientConfigurable</returns>
         public static IHockeyClientConfigurable Configure(this IHockeyClient @this, string appIdentifier, TelemetryConfiguration configuration = null)
         {
-            if (HockeyClient.CheckAndSetConfigured(@this))
+            if (@this.AsInternal().TestAndSetIsConfigured())
             {
                 return @this as IHockeyClientConfigurable;
             }

--- a/Src/Kit.Win81/HockeyClientExtensionsWin81.cs
+++ b/Src/Kit.Win81/HockeyClientExtensionsWin81.cs
@@ -25,6 +25,11 @@
         /// <returns>Configurable Hockey client. Configure additional settings by calling methods on the returned IHockeyClientConfigurable</returns>
         public static IHockeyClientConfigurable Configure(this IHockeyClient @this, string appIdentifier, TelemetryConfiguration configuration = null)
         {
+            if (HockeyClient.CheckAndSetConfigured(@this))
+            {
+                return @this as IHockeyClientConfigurable;
+            }
+
             @this.AsInternal().PlatformHelper = new HockeyPlatformHelper81();
             @this.AsInternal().AppIdentifier = appIdentifier;
 

--- a/Src/Kit.WinForms45/HockeyClientWinFormsExtensions.cs
+++ b/Src/Kit.WinForms45/HockeyClientWinFormsExtensions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.HockeyApp
         /// <returns>Instance object.</returns>
         public static IHockeyClientConfigurable Configure(this IHockeyClient @this, string identifier, string appId, string appVersion, string storeRegion, IDictionary<string, object> localApplicationSettings, IDictionary<string, object> roamingApplicationSettings, bool keepRunningAfterException = false)
         {
-            if (HockeyClient.CheckAndSetConfigured(@this))
+            if (@this.AsInternal().TestAndSetIsConfigured())
             {
                 return @this as IHockeyClientConfigurable;
             }

--- a/Src/Kit.WinForms45/HockeyClientWinFormsExtensions.cs
+++ b/Src/Kit.WinForms45/HockeyClientWinFormsExtensions.cs
@@ -55,6 +55,10 @@ namespace Microsoft.HockeyApp
         /// <returns>Instance object.</returns>
         public static IHockeyClientConfigurable Configure(this IHockeyClient @this, string identifier, string appId, string appVersion, string storeRegion, IDictionary<string, object> localApplicationSettings, IDictionary<string, object> roamingApplicationSettings, bool keepRunningAfterException = false)
         {
+            if (HockeyClient.CheckAndSetConfigured(@this))
+            {
+                return @this as IHockeyClientConfigurable;
+            }
             if (localApplicationSettings == null) throw new ArgumentNullException("localApplicationSettings");
             if (roamingApplicationSettings == null) throw new ArgumentNullException("roamingApplicationSettings");
 


### PR DESCRIPTION
I added a static method to HockeyClient to cut down on duplicated code (the null check followed by setting the value to true if it was false). It might be a bit weird, and if so I can remove it. The result of that will just be that there will be some slightly verbose duplicated code