### PR TITLE
Allow update of Version value in ApplicationService

### DIFF
--- a/Src/Kit.Core45/Services/IApplicationService.cs
+++ b/Src/Kit.Core45/Services/IApplicationService.cs
@@ -2,7 +2,10 @@
 {
     using System;
 
-    interface IApplicationService
+    /// <summary>
+    /// Interface IApplicationService
+    /// </summary>
+    public interface IApplicationService
     {
         /// <summary>
         /// Occurs when an app is suspending.
@@ -31,6 +34,11 @@
         /// </summary>
         /// <returns>The extracted data.</returns>
         string GetVersion();
+
+        /// <summary>
+        /// Sets the version for the current application.
+        /// </summary>
+        void SetVersion(string version);
 
         /// <summary>
         /// Gets the application id, which is then namespace name for App class.

--- a/Src/Kit.UWP/HockeyClientExtensionsUwp.cs
+++ b/Src/Kit.UWP/HockeyClientExtensionsUwp.cs
@@ -40,5 +40,21 @@
             WindowsAppInitializer.InitializeAsync(appId, configuration);
             return @this as IHockeyClientConfigurable;
         }
+
+        /// <summary>
+        /// Gets the application service.
+        /// </summary>
+        public static IApplicationService GetApplicationService(this IHockeyClient @this)
+        {
+            return ServiceLocator.GetService<IApplicationService>();
+        }
+
+        /// <summary>
+        /// Gets the service of the specified type.
+        /// </summary>
+        public static TService GetService<TService>(this IHockeyClient @this)
+        {
+            return ServiceLocator.GetService<TService>();
+        }
     }
 }

--- a/Src/Kit.UWP/Services/ApplicationService.cs
+++ b/Src/Kit.UWP/Services/ApplicationService.cs
@@ -96,6 +96,14 @@
         }
 
         /// <summary>
+        /// Sets the version for the current application.
+        /// </summary>
+        public void SetVersion(string version)
+        {
+            this.version = version;
+        }
+
+        /// <summary>
         /// Gets the application identifier, which is the namespace name for App class.
         /// </summary>
         /// <returns>Namespace name for App class.</returns>


### PR DESCRIPTION
In earlier versions of the SDK, it was possible to modify the Version value of HockeyClient. In UWP, this no longer works, the property can be set but the value is never used. UWP uses a class called ApplicationService which has its own version value. This PR adds a SetVersion method to ApplicationService and allows access to the services.

Unfortunately, all this is done using extension methods for IHockeyClient. So this will not fix the problem that setting the HockeyClient.Version has no effect on UWP.