### PR TITLE
Stack Trace workaround if only !<BaseAddress>+0x lines

### DIFF
--- a/Src/Kit.UWP/Services/UnhandledExceptionTelemetryModule.cs
+++ b/Src/Kit.UWP/Services/UnhandledExceptionTelemetryModule.cs
@@ -153,12 +153,13 @@
             string stackTrace = GetStrackTrace(exception);
             if (!string.IsNullOrEmpty(stackTrace))
             {
-                var stackTraceLines = stackTrace.Split(Environment.NewLine.ToCharArray());
-                bool hasResolvedLine = stackTraceLines.Any(line => line.IndexOf(@"!<BaseAddress>+0x", StringComparison.OrdinalIgnoreCase) < 0);
+                const string atPrefix = @"   at ";
+                string[] stackTraceLines = stackTrace.Split(Environment.NewLine.ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
+                bool hasResolvedLine = stackTraceLines.Any(line => line.StartsWith(atPrefix, StringComparison.OrdinalIgnoreCase) && line.IndexOf(@"!<BaseAddress>+0x", StringComparison.OrdinalIgnoreCase) < 0);
                 if (!hasResolvedLine)
                 {
-                    var stackTraceList = stackTraceLines.ToList();
-                    stackTraceList.Add(typeof(UnhandledExceptionTelemetryModule).FullName + "." + nameof(CreateCrashTelemetry) + "()");
+                    List<string> stackTraceList = stackTraceLines.ToList();
+                    stackTraceList.Add(atPrefix + typeof(UnhandledExceptionTelemetryModule).Name + ".FakeLocationHelper()");
                     stackTrace = string.Join(Environment.NewLine, stackTraceList);
                 }
             }


### PR DESCRIPTION
Check the stack trace if we need a dummy line at the end. Dummy line is required because if there are only "!\<BaseAddress\>+0x"-entries in the stack trace, HockeyApp gets confused.

In our application, we can see crash groups like this in HockeyApp:

```
0x000000005864da4f 0x000000005827c97d 0x000000005827df83 0x000000005827df15 0x0000000058283f8b 0x00000000586f7195 0x000000005827c97d 0x000000005827df83 0x000000005827df15 0x00000000580ca231 0x00000000589076a3 0x000000005827c97d 0x000000005827df83 0x000000
License request failed for asset 15469875: AggregateException_ctor_DefaultMessage.
```

This looks very strange. The crash details show this:

```
Exception Stack:
Customer.Uap10!<BaseAddress>+0x122da4f
Customer.Uap10!<BaseAddress>+0xe5c97d
Customer.Uap10!<BaseAddress>+0xe5df83
Customer.Uap10!<BaseAddress>+0xe5df15
Customer.Uap10!<BaseAddress>+0xe63f8b
Customer.Uap10!<BaseAddress>+0x12d7195
Customer.Uap10!<BaseAddress>+0xe5c97d
Customer.Uap10!<BaseAddress>+0xe5df83
Customer.Uap10!<BaseAddress>+0xe5df15
Customer.Uap10!<BaseAddress>+0xcaa231
Customer.Uap10!<BaseAddress>+0x14e76a3
Customer.Uap10!<BaseAddress>+0xe5c97d
Customer.Uap10!<BaseAddress>+0xe5df83
Customer.Uap10!<BaseAddress>+0xe5df15
Customer.Uap10!<BaseAddress>+0xe63f8b
Customer.Uap10!<BaseAddress>+0xe63e23
Customer.Uap10!<BaseAddress>+0xe5c97d
Customer.Uap10!<BaseAddress>+0xe5df83
Customer.Uap10!<BaseAddress>+0xe5df15
Customer.Uap10!<BaseAddress>+0xe63f8b
Customer.Uap10!<BaseAddress>+0x10feedd

Thread 24 Crashed:
0   Customer.Uap10                        0x000000005864da4f 0x0000000057420000 + 19061327
1   Customer.Uap10                        0x000000005827c97d 0x0000000057420000 + 15059325
2   Customer.Uap10                        0x000000005827df83 0x0000000057420000 + 15064963
3   Customer.Uap10                        0x000000005827df15 0x0000000057420000 + 15064853
4   Customer.Uap10                        0x0000000058283f8b 0x0000000057420000 + 15089547
5   Customer.Uap10                        0x00000000586f7195 0x0000000057420000 + 19755413
6   Customer.Uap10                        0x000000005827c97d 0x0000000057420000 + 15059325
7   Customer.Uap10                        0x000000005827df83 0x0000000057420000 + 15064963
8   Customer.Uap10                        0x000000005827df15 0x0000000057420000 + 15064853
9   Customer.Uap10                        0x00000000580ca231 0x0000000057420000 + 13279793
10  Customer.Uap10                        0x00000000589076a3 0x0000000057420000 + 21919395
11  Customer.Uap10                        0x000000005827c97d 0x0000000057420000 + 15059325
12  Customer.Uap10                        0x000000005827df83 0x0000000057420000 + 15064963
13  Customer.Uap10                        0x000000005827df15 0x0000000057420000 + 15064853
14  Customer.Uap10                        0x0000000058283f8b 0x0000000057420000 + 15089547
15  Customer.Uap10                        0x0000000058283e23 0x0000000057420000 + 15089187
16  Customer.Uap10                        0x000000005827c97d 0x0000000057420000 + 15059325
17  Customer.Uap10                        0x000000005827df83 0x0000000057420000 + 15064963
18  Customer.Uap10                        0x000000005827df15 0x0000000057420000 + 15064853
19  Customer.Uap10                        0x0000000058283f8b 0x0000000057420000 + 15089547
20  Customer.Uap10                        0x000000005851eedd 0x0000000057420000 + 17821405


Binary Images:
0x0000000057420000 - 0x0000000058c61000 +Customer.Uap10 unknown  <88e5828939b944859a941c9d6a542887-1> C:\Windows\ServiceProfiles\NetworkService\AppData\Local\Packages\appcompile-20170223-132432-22312\AC\Temp\Ilc1627669653\Native\Customer.Uap10.pdb
```

So, HockeyApp gets confused if there are only entries in the callstack that are unresolved and are in type of "!\<BaseAddress\>+0x". To have a workaround for this, after this PR we simply add a dummy line at the end of the callstack if we can only find "!\<BaseAddress\>+0x"-lines.