### PR TITLE
Fix SynchronizationLockException

### DIFF
--- a/Src/Kit.Core45/HockeyClient.cs
+++ b/Src/Kit.Core45/HockeyClient.cs
@@ -559,9 +559,8 @@
             }
         }
 
-#if NET_4_5
-        private readonly AsyncLock lck = new AsyncLock();
-#endif
+        private readonly AsyncLock _asyncLock = new AsyncLock();
+
         /// <summary>
         /// Send crash-logs from storage and deletes the if they could be sent
         /// </summary>
@@ -569,68 +568,49 @@
         public async Task<bool> SendCrashesAndDeleteAfterwardsAsync()
         {
             bool atLeatOneCrashSent = false;
-#if NET_4_5
-            using(var releaser = await lck.LockAsync()) { 
-#else
-            if (Monitor.TryEnter(this))
+            using (await _asyncLock.LockAsync())
             {
-                try
+                logger.Info("Start send crashes to platform.");
+                if (NetworkInterface.GetIsNetworkAvailable())
                 {
-#endif
-                    logger.Info("Start send crashes to platform.");
-                    if (NetworkInterface.GetIsNetworkAvailable())
+                    foreach (string filename in await this.GetCrashFileNamesAsync())
                     {
-                        foreach (string filename in await this.GetCrashFileNamesAsync())
+                        logger.Info("Crashfile found: {0}", filename);
+                        Exception error = null;
+                        try //don't stop if one file fails
                         {
-                            logger.Info("Crashfile found: {0}", filename);
-                            Exception error = null;
-                            try //don't stop if one file fails
+                            using (var stream = await this.PlatformHelper.GetStreamAsync(filename, SDKConstants.CrashDirectoryName))
                             {
-                                using (var stream = await this.PlatformHelper.GetStreamAsync(filename, SDKConstants.CrashDirectoryName))
-                                {
-                                    ICrashData cd = this.Deserialize(stream);
-                                    await cd.SendDataAsync();
-                                }
+                                ICrashData cd = this.Deserialize(stream);
+                                await cd.SendDataAsync();
+                            }
 
-                                atLeatOneCrashSent = true;
+                            atLeatOneCrashSent = true;
+                        }
+                        catch (Exception ex)
+                        {
+                            HandleInternalUnhandledException(ex);
+                            error = ex;
+                        }
+                        if (error != null && error is WebTransferException)
+                        {
+                            //will retry on next start
+                        }
+                        else
+                        {
+                            //either no error or the file seems corrupt => try to delete it
+                            try
+                            {
+                                await this.PlatformHelper.DeleteFileAsync(filename, SDKConstants.CrashDirectoryName);
                             }
                             catch (Exception ex)
                             {
                                 HandleInternalUnhandledException(ex);
-                                error = ex;
-                            }
-                            if (error != null && error is WebTransferException)
-                            {
-                                //will retry on next start
-                            }
-                            else
-                            {
-                                //either no error or the file seems corrupt => try to delete it
-                                try
-                                {
-                                    await this.PlatformHelper.DeleteFileAsync(filename, SDKConstants.CrashDirectoryName);
-                                }
-                                catch (Exception ex) {
-                                    HandleInternalUnhandledException(ex);
-                                }
                             }
                         }
                     }
                 }
-#if !NET_4_5
-                finally
-                {
-                    try
-                    {
-                        Monitor.Exit(this);
-                    }
-                    catch (Exception ex)
-                    { //ignore. on next start it will try again.
-                        HandleInternalUnhandledException(ex);
-                    }
-                }
             }
-#endif
             return atLeatOneCrashSent;
         }
 


### PR DESCRIPTION
Usage `Monitor` together with `await` cause to `SynchronizationLockException`. Good explanation [here](https://stackoverflow.com/a/21404261/1703290).
Also, I'm confused a bit because in project conditional symbols used `NET45` instead of `NET_4_5`. Anyway `Monitor` should be removed in any condition.

To reproduce this exception just use code like that:
```C#
protected override void OnStartup(StartupEventArgs e) {
    base.OnStartup(e);
    Task.Factory.StartNew(async delegate {
        await HockeyClient.Current.SendCrashesAsync();
    });
}
```
instead of
```C#
protected override async void OnStartup(StartupEventArgs e) {
    base.OnStartup(e);
    await HockeyClient.Current.SendCrashesAsync();
}
```

@achocron Could you look at it please?