### PR TITLE
OS version reporting update for Windows 10 compatibility

### DIFF
--- a/Src/Kit.WPF/HockeyPlatformHelperWPF.cs
+++ b/Src/Kit.WPF/HockeyPlatformHelperWPF.cs
@@ -236,11 +236,21 @@ namespace Microsoft.HockeyApp
         /// <summary>
         /// Gets OS version.
         /// </summary>
+        /// <remarks>
+        /// Starting from Windows 8 System.Environment.OsVersion.Version is only reliable to determine executing OS version
+        /// when the application is targeted for that OS version with a manifest file.
+        /// Otherwise only the registry values can be used.
+        /// <a href="https://msdn.microsoft.com/en-us/library/system.environment.osversion(v=vs.110).aspx">
+        /// System.Environment.OsVersion.Version / Remarks / Note section.
+        /// </a>
+        /// <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832(v=vs.85).aspx">
+        /// OS version and manifest file requirement for targeting.
+        /// </a>
+        /// </remarks>
         public string OSVersion
         {
             get
             {
-                //as windows 8.1 lies to us to be 8 we try via registry
                 try
                 {
                     using (RegistryKey registryKey = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\Windows NT\CurrentVersion"))
@@ -254,7 +264,7 @@ namespace Microsoft.HockeyApp
                             return newMajorVersion + "." + newMinorVersion + "." + newBuildNumber;
                         }
                         else {
-                            // Note: CurrentVersion is "<Major>.<Minor>".
+                            // Note: CurrentVersion registry entry is "<Major>.<Minor>".
                             return registryKey.GetValue("CurrentVersion", "0.0").ToString() + "." + registryKey.GetValue("CurrentBuild", "0").ToString();
                         }
                     }

--- a/Src/Kit.WPF/HockeyPlatformHelperWPF.cs
+++ b/Src/Kit.WPF/HockeyPlatformHelperWPF.cs
@@ -245,7 +245,18 @@ namespace Microsoft.HockeyApp
                 {
                     using (RegistryKey registryKey = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\Windows NT\CurrentVersion"))
                     {
-                        return (string)registryKey.GetValue("CurrentVersion") + "." + (string)registryKey.GetValue("CurrentBuild") + ".0";
+                        var newMajorVersion = registryKey.GetValue("CurrentMajorVersionNumber", 0).ToString();
+
+                        if (newMajorVersion != "0") {
+                            var newMinorVersion = registryKey.GetValue("CurrentMinorVersionNumber", 0).ToString();
+                            var newBuildNumber = registryKey.GetValue("CurrentBuildNumber", "0").ToString();
+
+                            return newMajorVersion + "." + newMinorVersion + "." + newBuildNumber;
+                        }
+                        else {
+                            // Note: CurrentVersion is "<Major>.<Minor>".
+                            return registryKey.GetValue("CurrentVersion", "0.0").ToString() + "." + registryKey.GetValue("CurrentBuild", "0").ToString();
+                        }
                     }
                 }
                 catch (Exception e)

--- a/Src/Kit.WinForms45/HockeyPlatformHelperWinForms.cs
+++ b/Src/Kit.WinForms45/HockeyPlatformHelperWinForms.cs
@@ -239,9 +239,45 @@ namespace Microsoft.HockeyApp
         /// <summary>
         /// Gets OS version.
         /// </summary>
+        /// <remarks>
+        /// Starting from Windows 8 System.Environment.OsVersion.Version is only reliable to determine executing OS version
+        /// when the application is targeted for that OS version with a manifest file.
+        /// Otherwise only the registry values can be used.
+        /// <a href="https://msdn.microsoft.com/en-us/library/system.environment.osversion(v=vs.110).aspx">
+        /// System.Environment.OsVersion.Version / Remarks / Note section.
+        /// </a>
+        /// <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832(v=vs.85).aspx">
+        /// OS version and manifest file requirement for targeting.
+        /// </a>
+        /// </remarks>
         public string OSVersion
         {
-            get { return Environment.OSVersion.Version.ToString() + " " + Environment.OSVersion.ServicePack; }
+            get
+            {
+                try
+                {
+                    using (RegistryKey registryKey = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\Windows NT\CurrentVersion"))
+                    {
+                        var newMajorVersion = registryKey.GetValue("CurrentMajorVersionNumber", 0).ToString();
+
+                        if (newMajorVersion != "0") {
+                            var newMinorVersion = registryKey.GetValue("CurrentMinorVersionNumber", 0).ToString();
+                            var newBuildNumber = registryKey.GetValue("CurrentBuildNumber", "0").ToString();
+
+                            return newMajorVersion + "." + newMinorVersion + "." + newBuildNumber;
+                        }
+                        else {
+                            // Note: CurrentVersion registry entry is "<Major>.<Minor>".
+                            return registryKey.GetValue("CurrentVersion", "0.0").ToString() + "." + registryKey.GetValue("CurrentBuild", "0").ToString();
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    HockeyClient.Current.AsInternal().HandleInternalUnhandledException(e);
+                }
+                return Environment.OSVersion.Version.ToString() + " " + Environment.OSVersion.ServicePack;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
**Bug:**
I have noticed that WPF applications without corresponding [manifest file](https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832(v=vs.85).aspx), on Windows 10 machines have caused HockeyApp to report incorrect OS version number, 6.x instead of 10.x.

**Root cause:**
Before Windows 10 the registry entry `CurrentVersion` at key `HKLM\Software\Microsoft\Windows NT\CurrentVersion\` could be used to determine the OS major and minor version regardless whether the app had a manifest file targeting it for that specific OS version.
The [WPF](https://github.com/bitstadium/HockeySDK-Windows/blob/community/Src/Kit.WPF/HockeyPlatformHelperWPF.cs) and [Windows Forms](https://github.com/bitstadium/HockeySDK-Windows/blob/community/Src/Kit.WinForms45/HockeyPlatformHelperWinForms.cs) `OSVersion` attributes used these registry entries to determine the correct OS version.

From Windows 10 this registry does not hold the correct OS version number anymore, `CurrentMajorVersionNumber` and `CurrentMinorVersionNumber` do, behind the same registry key.

**Solution:**
I updated the above-mentioned files to read the new registry entries first and use them if they are defined, otherwise default back to retrieving the OS version the old way.

