### PR TITLE
fix WebBrowser default encoding to utf-8

### DIFF
--- a/Src/Kit.WPF/Gui/UpdateWindow.xaml
+++ b/Src/Kit.WPF/Gui/UpdateWindow.xaml
@@ -35,7 +35,7 @@
         <Grid Grid.Row="0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="30"/>
-                <RowDefinition Height="40"/>
+                <RowDefinition Height="45"/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
@@ -43,10 +43,10 @@
             </Grid.ColumnDefinitions>
             <ContentPresenter Content="{StaticResource UpdateIcon}" Width="70" Height="70" Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"/>
             <TextBlock Name="txtTopic" FontSize="24" Height="30" VerticalAlignment="Top" Grid.Row="0" />
-            <TextBlock Name="txtText"  TextWrapping="Wrap" Height="40" VerticalAlignment="Top" Grid.Row="1" />
+            <TextBlock Name="txtText"  TextWrapping="Wrap" Height="40" VerticalAlignment="Top" Margin="0,5,0,0" Grid.Row="1" />
         </Grid>
 
-        <TextBlock Name="txtReleaseNotes" Text="Release notes:" Grid.Row="1" FontSize="16" VerticalAlignment="Center" Margin="0,16,0,4"/>
+        <TextBlock Name="txtReleaseNotes" Text="Release notes" Grid.Row="1" FontSize="16" VerticalAlignment="Center" Margin="0,16,0,4"/>
         <Border  BorderBrush="#3F3F46" BorderThickness="1" Grid.Row="2">
             <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
                 <WebBrowser x:Name="releaseNotes" />

--- a/Src/Kit.WPF/Gui/UpdateWindow.xaml.cs
+++ b/Src/Kit.WPF/Gui/UpdateWindow.xaml.cs
@@ -47,6 +47,21 @@ namespace Microsoft.HockeyApp.Gui
                 };
             }
         }
+
+        /// <summary>
+        /// Make WebBrowser encoding to utf-8  
+        /// </summary>
+        /// <param name="text"></param>
+        /// <returns></returns>
+        private string utf8html(string text)
+        {
+            var sb = new StringBuilder();
+            sb.Append("<html><head><meta charset='utf-8'></head>");
+            sb.Append("<body>");
+            sb.Append(text);
+            sb.Append("</body></html>");
+            return sb.ToString();
+        }
      
         private void btnInstall_Click(object sender, RoutedEventArgs e)
         {

--- a/Src/Kit.WPF/Gui/UpdateWindow.xaml.cs
+++ b/Src/Kit.WPF/Gui/UpdateWindow.xaml.cs
@@ -39,7 +39,7 @@ namespace Microsoft.HockeyApp.Gui
             this.txtReleaseNotes.Text = LocalizedStrings.LocalizedResources.ReleaseNotes;
             if (!string.IsNullOrWhiteSpace(newVersion.Notes))
             {
-                this.releaseNotes.NavigateToString(newVersion.Notes);
+                this.releaseNotes.NavigateToString(makeUtf8html(newVersion.Notes));
                 this.releaseNotes.Navigating += (sender, args) =>
                 {
                     Process.Start(args.Uri.ToString());
@@ -53,7 +53,7 @@ namespace Microsoft.HockeyApp.Gui
         /// </summary>
         /// <param name="text"></param>
         /// <returns></returns>
-        private string utf8html(string text)
+        private string makeUtf8html(string text)
         {
             var sb = new StringBuilder();
             sb.Append("<html><head><meta charset='utf-8'></head>");


### PR DESCRIPTION
Currently, WPF update dialog `Release Note` characters are broken when we wrote in utf-8 sensitive language such as Korean, Japanese, Chinese.
This fix adjusts charset to utf-8 as same as HockeyApp webpage, which could give identical view of web management and update dialog.
In addition, I gave small GUI modification in order to improve update dialog GUI.