### PR TITLE
Fix crash in global exception handler on newer Windows versions

### DIFF
--- a/Src/Kit.UWP/Services/UnhandledExceptionTelemetryModule.cs
+++ b/Src/Kit.UWP/Services/UnhandledExceptionTelemetryModule.cs
@@ -167,7 +167,7 @@
 
                     telemetry.Threads[0].Frames.Add(crashFrame);
                     long nativeImageBase = frame.GetNativeImageBase().ToInt64();
-                    if (seenBinaries.Contains(nativeImageBase))
+                    if (seenBinaries.Contains(nativeImageBase) || nativeImageBase == 0)
                     {
                         continue;
                     }


### PR DESCRIPTION
The fix is to check native image base address before parsing