### PR TITLE
Fix issue where cached events/crashes where wrongly deleted

### DIFF
--- a/Src/Kit.Core45/Channels/Persistence/Sender.cs
+++ b/Src/Kit.Core45/Channels/Persistence/Sender.cs
@@ -286,17 +286,29 @@ namespace Microsoft.HockeyApp.Channel
         /// </summary>
         private static bool IsRetryable(int? httpStatusCode, WebExceptionStatus webExceptionStatus)
         {
-            // ToDo: Handle correctly this for NET45
-//#if NET40 || NET45 // WINRT doesn't support ProxyNameResolutionFailure/NameResolutionFailure/Timeout/ConnectFailure, for WinPhone this seems like a corner scenario and we don't want to spend the effot to test it now.
-//            switch (webExceptionStatus)
-//            {
-//                case WebExceptionStatus.ProxyNameResolutionFailure:
-//                case WebExceptionStatus.NameResolutionFailure:
-//                case WebExceptionStatus.Timeout:
-//                case WebExceptionStatus.ConnectFailure:
-//                    return true;
-//            }
-//#endif 
+#if NET40 || NET45 
+
+            // Can't use this code, as some values of the WebExceptionStatus enum are not defined in the portable, e.g. WINRT doesn't support ProxyNameResolutionFailure/NameResolutionFailure/Timeout/ConnectFailure
+            //            switch (webExceptionStatus)
+            //            {
+            //                case WebExceptionStatus.ProxyNameResolutionFailure:
+            //                case WebExceptionStatus.NameResolutionFailure:
+            //                case WebExceptionStatus.Timeout:
+            //                case WebExceptionStatus.ConnectFailure:
+            //                    return true;
+            //            }
+
+            // Use string comparison instead
+            switch (webExceptionStatus.ToString())
+            {
+                case "ProxyNameResolutionFailure":
+                case "NameResolutionFailure":
+                case "Timeout":
+                case "ConnectFailure":
+                    return true;
+            }
+#endif 
+
             if (httpStatusCode == null)
             {
                 return false;


### PR DESCRIPTION
In short:
Upon repeatedly failing connections cached files are wrongly deleted.

Reproduction:
- If the app is quickly used and closed, no events will be send and the events are not cached. If I call `HockeyClient.Current.Flush()` on shutdown of the app events are cached and send on next start of the App. This is expected behaviour.
- If the network connection is deactivated, obviously no data can be send. Crashes and events are cached as files are written into `LocalState\HockeyApp` and `LocalState\HockeyCrashes` folders of the app. This is expected behaviour.
- What doesn't work then is, with still deactivated network, a call to `HockeyClient.Current.SendCrashesAsync(true)` on the next start of the app will delete the cached crash file and on the next call to `HockeyClient.Current.Flush()` the cached event file is deleted, even though there's no way these can be send.

Therefore any cached data is lost.